### PR TITLE
ci: Use snake_case inputs for first-interaction

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: "👋 Hi there! Thanks for opening your first issue. We will look into it soon."
-          pr-message: "🎉 Congrats on your first Pull Request! Please make sure you have run `ruff check . && ruff format` before submitting."
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: "👋 Hi there! Thanks for opening your first issue. We will look into it soon."
+          pr_message: "🎉 Congrats on your first Pull Request! Please make sure you have run `ruff check . && ruff format` before submitting."


### PR DESCRIPTION
Update .github/workflows/welcome.yml to use the action's expected input names for actions/first-interaction@v3: repo_token, issue_message, and pr_message (replacing repo-token, issue-message, and pr-message). This aligns the workflow with the action's input naming and prevents input parsing errors; the welcome messages remain unchanged.